### PR TITLE
Update warnings to match the MDC iOS project

### DIFF
--- a/strict_warnings_objc_library.bzl
+++ b/strict_warnings_objc_library.bzl
@@ -17,13 +17,28 @@ COMMON_COPTS = [
     "-Wnewline-eof",  # No newline at the end of the file.
     "-Wno-error=deprecated",  # Deprecation warnings are never errors.
     "-Wno-error=deprecated-implementations",  # Deprecation warnings are never errors.
+    "-Wno-partial-availability",
     "-Wno-sign-conversion",  # Do not warn on sign conversions.
     "-Wno-unused-parameter",  # Do not warn on unused parameters.
     "-Woverlength-strings",  # Strings longer than the C maximum.
     "-Wshadow",  # Local variable shadows another variable, parameter, etc.
     "-Wstrict-selector-match",  # Compiler can't figure out the right selector.
+    "-Wstrict-prototypes",
     "-Wundeclared-selector",  # Compiler doesn't see a selector.
     "-Wunreachable-code",  # Code will never be reached.
+    "-Wunused-comparison",
+    "-Wunused-const-variable",
+    "-Wunused-exception-parameter",
+    "-Wunused-function",
+    "-Wunused-label",
+    "-Wunused-member-function",
+    "-Wunused-private-field",
+    "-Wunused-property-ivar",
+    "-Wunused-result",
+    "-Wunused-value",
+    "-Wunused-variable",
+    "-Wunused-volatile-lvalue",
+    "-Wused-but-marked-unused",
 ]
 
 def strict_warnings_objc_library(


### PR DESCRIPTION
From: https://github.com/material-components/material-components-ios/blob/develop/catalog/MaterialComponentsWarnings.xcconfig