### PR TITLE
Disable `unused-parameter` warnings.

### DIFF
--- a/strict_warnings_objc_library.bzl
+++ b/strict_warnings_objc_library.bzl
@@ -39,6 +39,7 @@ COMMON_COPTS = [
     "-Wunused-variable",
     "-Wunused-volatile-lvalue",
     "-Wused-but-marked-unused",
+    "-Wno-unused-parameter",  # Enabled by -Wall via -Wunused, problems with params used in asserts.
 ]
 
 def strict_warnings_objc_library(


### PR DESCRIPTION
These warnings cause build failures in release builds when arguments are tested with debug-only assertions.

This will be a breaking change.