### PR TITLE
remove newline-eof from strict warnings

### DIFF
--- a/strict_warnings_objc_library.bzl
+++ b/strict_warnings_objc_library.bzl
@@ -14,7 +14,6 @@ COMMON_COPTS = [
     "-Wdocumentation",  # Warn when documentation is out of date.
     "-Wimplicit-atomic-properties",  # Dynamic properties should be non-atomic.
     "-Wmissing-prototypes",  # Global function is defined without a previous prototype.
-    "-Wnewline-eof",  # No newline at the end of the file.
     "-Wno-error=deprecated",  # Deprecation warnings are never errors.
     "-Wno-error=deprecated-implementations",  # Deprecation warnings are never errors.
     "-Wno-partial-availability",


### PR DESCRIPTION
While newline-eof is a warning, it is not a very useful one. It causes build breakage with no real win to the end projects that have it turned on.